### PR TITLE
Fix orb when using stable-4.6 branch on GAP.dev

### DIFF
--- a/gap/hash.gi
+++ b/gap/hash.gi
@@ -778,7 +778,8 @@ else
       end );
 fi;
 
-if CompareVersionNumbers(GAPInfo.Version,"4.7") then
+# compatibility with GAP 4.7
+if IsBound(IsTrans2Rep) then
     InstallGlobalFunction( ORB_HashFunctionForTransformations,
      function(t,data)
        if IsTrans2Rep(t) then 
@@ -811,7 +812,8 @@ InstallMethod( ChooseHashFunction, "for permutations",
     return rec( func := ORB_HashFunctionForPermutations, data := hashlen );
   end );
 
-if CompareVersionNumbers(GAPInfo.Version,"4.7") then
+# compatibility with GAP 4.7
+if IsBound(IsTrans2Rep) then
     InstallMethod( ChooseHashFunction, "for transformations",
       [IsTransformation, IsInt],
       function(t,hashlen)
@@ -897,7 +899,8 @@ InstallMethod( ChooseHashFunction,
     TryNextMethod();
   end );
 
-if CompareVersionNumbers(GAPInfo.Version,"4.7") then
+# compatibility with GAP 4.7
+if IsBound(IsPartialPerm) then
     InstallGlobalFunction( ORB_HashFunctionForPartialPerms,
     function(t,data)
       if IsPPerm2Rep(t) then 


### PR DESCRIPTION
When running GAP.dev, GAPInfo.Version is set to "4.dev", which is higher
than any other 4.x version -- so the checks for GAP 4.7 were triggered,
even though the features those checks look for are not actually present.

Instead of looking for versions to decide which code to load, we now
look for specific features the conditionally loaded code uses.
