### PR TITLE
Add a hash function for blists

### DIFF
--- a/gap/hash.gi
+++ b/gap/hash.gi
@@ -899,6 +899,13 @@ if IsBound(IsPartialPerm) then
     end );
 fi;
 
+InstallMethod(ChooseHashFunction, "for a blist and pos int",
+[IsBlistRep, IsPosInt],
+  function(x, hashlen)
+  return rec(func := HASH_FUNC_FOR_BLIST,
+             data := hashlen);
+end);
+
 ##
 ##  This program is free software: you can redistribute it and/or modify
 ##  it under the terms of the GNU General Public License as published by

--- a/src/orb.c
+++ b/src/orb.c
@@ -1484,6 +1484,20 @@ Obj FuncMappingPermListList(Obj self, Obj src, Obj dst)
     return FuncPermList(self,out);
 }
 
+Obj HASH_FUNC_FOR_BLIST (Obj self, Obj blist, Obj data_gap) {
+
+  size_t res  = 0;
+  UInt   nr  = NUMBER_BLOCKS_BLIST(blist);
+  UInt*  ptr  = BLOCKS_BLIST(blist);
+  UInt   data = INT_INTOBJ(data_gap);
+
+  while (nr > 0) {
+    res = (res * 23) + *(ptr++);
+    nr--;
+  }
+  return INTOBJ_INT((res % data) + 1);
+}
+
 /*F * * * * * * * * * * * * * initialize package * * * * * * * * * * * * * * */
 
 /******************************************************************************
@@ -1570,6 +1584,10 @@ static StructGVarFunc GVarFuncs [] = {
   { "MappingPermListList_C", 2, "src, dst",
     FuncMappingPermListList,
     "pkg/orb/src/orb.c:FuncMappingPermListList" },
+  
+  { "HASH_FUNC_FOR_BLIST", 2, "blist, data",
+    HASH_FUNC_FOR_BLIST,
+    "pkg/orb/src/orb.c:HASH_FUNC_FOR_BLIST" },
 
   { 0 }
 

--- a/tst/hash.tst
+++ b/tst/hash.tst
@@ -1,0 +1,53 @@
+#############################################################################
+##
+#W  hash.tst
+#Y  Copyright (C) 2016                                   James D. Mitchell
+##
+##  Licensing information can be found in the README file of this package.
+##
+#############################################################################
+##
+
+#
+gap> START_TEST("Orb package: hash.tst");
+gap> LoadPackage("orb", false);;
+
+# test HASH_FUNC_FOR_BLIST and its distribution
+gap> bl := BlistList([1 .. 10000], []);;
+gap> HASH_FUNC_FOR_BLIST(bl, 101);
+1
+gap> li := Combinations([1 .. 5]);;
+gap> Collected(List(li, x -> HASH_FUNC_FOR_BLIST(BlistList([1 .. 5], x), 101)));
+[ [ 1, 1 ], [ 2, 1 ], [ 3, 1 ], [ 4, 1 ], [ 5, 1 ], [ 6, 1 ], [ 7, 1 ], 
+  [ 8, 1 ], [ 9, 1 ], [ 10, 1 ], [ 11, 1 ], [ 12, 1 ], [ 13, 1 ], [ 14, 1 ], 
+  [ 15, 1 ], [ 16, 1 ], [ 17, 1 ], [ 18, 1 ], [ 19, 1 ], [ 20, 1 ], 
+  [ 21, 1 ], [ 22, 1 ], [ 23, 1 ], [ 24, 1 ], [ 25, 1 ], [ 26, 1 ], 
+  [ 27, 1 ], [ 28, 1 ], [ 29, 1 ], [ 30, 1 ], [ 31, 1 ], [ 32, 1 ] ]
+gap> Collected(List(li, x -> HASH_FUNC_FOR_BLIST(BlistList([1 .. 5], x), 37)));
+[ [ 1, 1 ], [ 2, 1 ], [ 3, 1 ], [ 4, 1 ], [ 5, 1 ], [ 6, 1 ], [ 7, 1 ], 
+  [ 8, 1 ], [ 9, 1 ], [ 10, 1 ], [ 11, 1 ], [ 12, 1 ], [ 13, 1 ], [ 14, 1 ], 
+  [ 15, 1 ], [ 16, 1 ], [ 17, 1 ], [ 18, 1 ], [ 19, 1 ], [ 20, 1 ], 
+  [ 21, 1 ], [ 22, 1 ], [ 23, 1 ], [ 24, 1 ], [ 25, 1 ], [ 26, 1 ], 
+  [ 27, 1 ], [ 28, 1 ], [ 29, 1 ], [ 30, 1 ], [ 31, 1 ], [ 32, 1 ] ]
+gap> Collected(List(li, x -> HASH_FUNC_FOR_BLIST(BlistList([1 .. 5], x), 17)));
+[ [ 1, 2 ], [ 2, 2 ], [ 3, 2 ], [ 4, 2 ], [ 5, 2 ], [ 6, 2 ], [ 7, 2 ], 
+  [ 8, 2 ], [ 9, 2 ], [ 10, 2 ], [ 11, 2 ], [ 12, 2 ], [ 13, 2 ], [ 14, 2 ], 
+  [ 15, 2 ], [ 16, 1 ], [ 17, 1 ] ]
+
+# test ChooseHashFunction for a blist
+gap> ht := HTCreate(bl);
+<tree hash table len=100003 used=0 colls=0 accs=0>
+gap> HTAdd(ht, bl, true);
+1
+gap> ht;
+<tree hash table len=100003 used=1 colls=0 accs=1>
+gap> ht!.hf = HASH_FUNC_FOR_BLIST;
+true
+gap> for x in Combinations([1 .. 5]) do 
+>      HTAdd(ht, BlistList([1 .. 5], x), true);
+>    od;
+gap> ht;
+<tree hash table len=100003 used=33 colls=1 accs=33>
+
+#
+gap> STOP_TEST("Semigroups package: testinstall.tst", 10000);


### PR DESCRIPTION
This commit includes a special hash function for `IsBlistRep`, a method
for `ChooseHashFunction`, and some tests. 

This was requested by @egri-nagy.