### PR TITLE
hash: fix hashing of permutations

### DIFF
--- a/gap/hash.gi
+++ b/gap/hash.gi
@@ -752,7 +752,7 @@ function(p,data)
   if IsPerm4Rep(p) then
     # is it a proper 4byte perm?
     if l>65536 then
-      return HashKeyBag(p,255,0,4*l) mod data + 1;
+      return HashKeyBag(p,255,ORBC.PERM_HASH_SKIP,4*l) mod data + 1;
     else
       # the permutation does not require 4 bytes. Trim in two
       # byte representation (we need to do this to get consistent
@@ -761,7 +761,7 @@ function(p,data)
     fi;
    fi;
    # now we have a Perm2Rep:
-   return HashKeyBag(p,255,0,2*l) mod data + 1;
+   return HashKeyBag(p,255,ORBC.PERM_HASH_SKIP,2*l) mod data + 1;
 end );
 
 InstallGlobalFunction( ORB_HashFunctionForPlainFlatList,

--- a/src/orb.c
+++ b/src/orb.c
@@ -1534,7 +1534,16 @@ static Int InitLibrary ( StructInitInfo *module )
     /* init filters and functions */
     InitGVarFuncsFromTable(GVarFuncs);
 
-    tmp = NEW_PREC(0);
+    tmp = NEW_PREC(1);
+
+    // In GAP 4.9, the memory layout of T_PERM objects changed, and so the
+    // method for hashing permutations also had to be changed. The following is
+    // used to define the "skip" argument of HASHKEY_BAG, i.e. where in the
+    // bag, containing the permutation, the list of images starts.
+    Obj p = NEW_PERM2(0);
+    AssPRec(tmp, RNamName("PERM_HASH_SKIP"),
+            INTOBJ_INT((UInt) ADDR_PERM2(p) - (UInt) ADDR_OBJ(p)));
+    CHANGED_BAG(tmp);
     gvar = GVarName("ORBC"); AssGVar( gvar, tmp ); MakeReadOnlyGVar(gvar);
 
     /* return success                                                      */


### PR DESCRIPTION
The shape of the bag containing a permutation has changed in GAP due to
the caching of the inverses introduced recently by Steve Linton. This
commit updates the hashing of permutations in Orb so that it works
again.