### PR TITLE
Make Orb option lookingfor accept non legacy HT

### DIFF
--- a/gap/orbits.gi
+++ b/gap/orbits.gi
@@ -171,7 +171,7 @@ InstallGlobalFunction( Orb,
         o.looking := true;
         if IsList(o.lookingfor) then
             o.lookfunc := ORB_LookForList;
-        elif IsRecord(o.lookingfor) and IsBound(o.lookingfor.ishash) then
+        elif IsHashTab(o.lookingfor) then
             o.lookfunc := ORB_LookForHash;
         elif IsFunction(o.lookingfor) then
             o.lookfunc := o.lookingfor;


### PR DESCRIPTION
This change makes it possible to pass a hashtable created via HTCreate
(instead of the legacy NewHT) to the Orb option lookingfor. This is
necessary since passing a legacy hashtable lead to an error during orbit
enumeration due to calls to HTValue, making the lookingfor option
unusable.