### PR TITLE
CI: don't test on stable-4.10; do test on stable-4.12

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,8 +25,9 @@ jobs:
       matrix:
         gap-branch:
           - master
+          - stable-4.12
           - stable-4.11
-          - stable-4.10
+          #- stable-4.10  # disabled due to AtlasGrp failures
           - stable-4.9
         ABI: ['']
         include:


### PR DESCRIPTION
The tests on stable-4.10 are broken because the atlasrep version
there is unable to download data
