### PR TITLE
Catch more bad invocations of hash functions

### DIFF
--- a/tst/bugfix.tst
+++ b/tst/bugfix.tst
@@ -17,5 +17,50 @@ gap> ht := HTCreate(bl);;
 gap> HTAdd(ht, 1, 1);
 Error, hash function not applicable to key of type integer
 
+# verify equal vectors either have equal hashes, or at least one gives fail
+# (here for 8 bit vector rep)
+gap> v:=[1..100]*Z(5);;
+gap> w:=CopyToVectorRep(v,5);;
+gap> v = w;
+true
+gap> IsPlistRep(v);
+true
+gap> Is8BitVectorRep(w);
+true
+gap> hf:=ChooseHashFunction(w, 1009);;
+gap> hf.func(w, hf.data);
+799
+gap> hf.func(v, hf.data);
+fail
+
+# now the other way around
+gap> hf:=ChooseHashFunction(v, 1009);;
+gap> hf.func(w, hf.data);
+651
+gap> hf.func(v, hf.data);
+651
+
+# same check for GF(2)
+gap> v:=[1..100]*Z(2);;
+gap> w:=CopyToVectorRep(v,2);;
+gap> v = w;
+true
+gap> IsPlistRep(v);
+true
+gap> IsGF2VectorRep(w);
+true
+gap> hf:=ChooseHashFunction(w, 1009);;
+gap> hf.func(w, hf.data);
+573
+gap> hf.func(v, hf.data);
+fail
+
+# now the other way around
+gap> hf:=ChooseHashFunction(v, 1009);;
+gap> hf.func(w, hf.data);
+446
+gap> hf.func(v, hf.data);
+446
+
 #
 gap> STOP_TEST("Orb package: bugfix.tst", 0);


### PR DESCRIPTION
More hash functions now detect invalid input and return `fail`
instead of returning garbage (like hashes of random memory blocks,
or the constant 0) or even crashing.

Returning something like 0 violates the crucial invariant that
objects which compare as equal must have equal hashes. This could
happen if e.g. a hash function for compressed vectors was invoked
with input a non-compressed vector.

Also be a bit more paranoid when computing hashes of permutations,
partial permutations and transformations: just because right now
all of those have an internal rep with 2 or 4 bytes per component
does not mean this will always be the case.

This change may result in existing code to suddenly produce errors
that weren't reported before. It is almost guaranteed that this hints
at a potentially dangerous bug in the original code.
