### PR TITLE
CI: drop 32bit tests

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -27,7 +27,7 @@ jobs:
           - master
           - stable-4.12
           - stable-4.11
-          #- stable-4.10  # disabled due to AtlasGrp failures
+          - stable-4.10
           - stable-4.9
 
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.ABI }}
+    name: ${{ matrix.gap-branch }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -29,10 +29,6 @@ jobs:
           - stable-4.11
           #- stable-4.10  # disabled due to AtlasGrp failures
           - stable-4.9
-        ABI: ['']
-        include:
-          - gap-branch: master
-            ABI: 32
 
     steps:
       - uses: actions/checkout@v3
@@ -40,7 +36,6 @@ jobs:
         with:
           GAP_PKGS_TO_BUILD: "io profiling cvec"
           GAPBRANCH: ${{ matrix.gap-branch }}
-          ABI: ${{ matrix.ABI }}
       - uses: gap-actions/build-pkg@v1
       - uses: gap-actions/run-pkg-tests@v2
       - uses: gap-actions/process-coverage@v2

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -8,7 +8,14 @@ LoadPackage("io");
 LoadPackage("orb");
 
 d := DirectoriesPackageLibrary("orb", "tst");
+exclude:=[];
+if not CompareVersionNumbers(GAPInfo.Version, "4.12") then
+  Append(exclude, [
+    "m11PF3d24/M11OrbitOnPF3d24.tst",
+    "m22p770.tst",
+  ]);
+fi;
 
-TestDirectory(d[1], rec(exitGAP := true));
+TestDirectory(d[1], rec(exitGAP := true, exclude:=exclude));
 
 FORCE_QUIT_GAP(1);


### PR DESCRIPTION
They don't work in latest Ubuntu and also are not really relevant anymore
