### PR TITLE
renaming methods in homwdata.gi to PreImages...NC

### DIFF
--- a/gap/homwdata.gi
+++ b/gap/homwdata.gi
@@ -56,14 +56,15 @@ InstallMethod( PreImageElm, "for a mapping by function with data, and an obj",
   return h!.invFun(h!.data,o);
   end );
 
-InstallMethod( PreImagesElm, "for a mapping by function with data, and an obj",
+InstallMethod( PreImagesElmNC,
+  "for a mapping by function with data, and an obj",
   [ IsMappingByFunctionWithInverseRep and IsMappingByFunctionWithData, 
     IsObject ], 0,
   function (h,o)
   return [h!.invFun(h!.data,o)];
   end );
 
-InstallMethod( PreImagesRepresentative, 
+InstallMethod( PreImagesRepresentativeNC, 
   "for a mapping by function with data, and an obj",
   [ IsMappingByFunctionWithInverseRep and IsMappingByFunctionWithData, 
     IsObject ], 0,
@@ -71,7 +72,7 @@ InstallMethod( PreImagesRepresentative,
   return h!.invFun(h!.data,o);
   end );
 
-InstallMethod( PreImagesRepresentative, 
+InstallMethod( PreImagesRepresentativeNC, 
   "for a mapping by function with invmap with data, and an obj",
   [ IsMappingByFunctionRep and IsMappingByFunctionWithData, 
     IsObject ], 0,

--- a/init.g
+++ b/init.g
@@ -34,6 +34,16 @@ if not IsBound(MultVector) then
     DeclareSynonym( "MultVector", MultRowVector );
 fi;
 
+#
+#I introduce the NC versions of PreImages...
+#
+if not IsBound( PreImagesElmNC ) then
+    BindGlobal( "PreImagesElmNC", PreImagesElm );
+fi;
+if not IsBound( PreImagesRepresentativeNC ) then
+    BindGlobal( "PreImagesRepresentativeNC", PreImagesRepresentative );
+fi;
+
 ReadPackage("orb","gap/homwdata.gd");
 ReadPackage("orb","gap/avltree.gd");
 ReadPackage("orb","gap/hash.gd");


### PR DESCRIPTION
PreImages, PreImagesElm, PreImagesSet and PreImagesRepresentative, can all return incorrect results when the element(s) supplied are not in the range of the map.
This situation has been discussed in GAP issue #4809.
To rectify the situation the plan is to have NC versions of these four operations and to add tests to the non-NC versions.
The procedure to be adopted is as follows.
(1) Rename the four operations by adding 'NC' to their names, and then declare the original operations as synonyms of these. PR#5073 addresses this.
(2) Ask package authors/maintainers to convert all their methods for these functions to the NC versions (unless there is good reason not to do so).
A clause added to init.g ensures that the package still works in older versions of GAP.
(3) Once all the packages have been updated, add tests to the non-NC versions of the operations.

This PR attempts to implement (2) for package orb which has one method for PreImagesElm and two methods for PreImagesRepresentative in the file homwdata.gi. These methods do no tests so should be NC versions.
These methods are apparently not called anywhere in the orb library or in any of the tests, so maybe this change is unnecessary?

This file also has methods for ImagesElm and ImagesRepresentative. It has been suggested that these should also have NC versions as part of PR#5073, but no decision has been made to date. Any comment?