### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/orb.c
+++ b/src/orb.c
@@ -9,7 +9,7 @@
 
 #include <stdlib.h>
 
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 
 /* This file corresponds to orb/gap/avltree.gi, it imlements some of
  * its functionality on the C level for better performance. */


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
